### PR TITLE
Add keyboard support for Dell Latitude 5400 Chromebook (Sarien) 

### DIFF
--- a/configs/keyboard-layouts/cros-sarien.conf
+++ b/configs/keyboard-layouts/cros-sarien.conf
@@ -1,0 +1,50 @@
+# Tigerlake and newer Chromebooks are vivaldi only, with a new keyboard layout
+
+[ids]
+# AT keyboard is device 0001:0001
+0001:0001
+
+[main]
+back = back
+refresh = refresh
+zoom = f11
+scale = scale
+print = print
+camera = brightnessdown
+prog1 = brightnessup
+mute = mute
+volumedown = volumedown
+volumeup = volumeup
+# the lock button is mapped to sleep by default
+sleep = coffee
+
+# When search key is held make the top row act like function keys
+[meta]
+back = f1
+refresh = f2
+zoom = f3
+scale = f4
+camera = f5
+prog1 = f6
+mute = f7
+volumedown = f8
+volumeup = f9
+# no need for F10 as F10 is already recognized as F10
+# no need for F11 as the fullscreen button is mapped to f11
+switchvideomode = f12
+
+
+######## ChromeOS shortcuts ########
+[alt]
+# alt + backspace = delete
+backspace = delete
+# alt + meta = capslock
+meta = capslock
+# alt + brightness = keyboardbacklightbrightness
+camera = kbdillumdown
+prog1 = kbdillumup
+
+######## Extra shortcuts ########
+[control+alt]
+# Ctrl + alt + backspace = ctrl + alt + delete
+backspace = C-A-delete

--- a/system-scripts/set-keymap
+++ b/system-scripts/set-keymap
@@ -63,6 +63,8 @@ if __name__ == "__main__":
                 selected_layout = "cros-standard.conf"
             case "jinlon":  # aka HP Chromebook x360 13c / Elite c1030
                 selected_layout = "cros-jinlon.conf"
+            case "sarien":  # aka Dell Latitude 5400 Chromebook
+                selected_layout = "cros-sarien.conf"
             case _:
                 # Use the board-generations file of the audio setup script to determine which layout should be used
                 with open("/usr/share/eupnea/audio/board-generations.json", "r") as generations:


### PR DESCRIPTION
The Dell Latitude 5400 Chromebook (Sarien) has an uncommon keyboard layout for Chromebooks.
Brightness and Keyboard brightness were not working out of the box. I found the Key names using `sudo keyd monitor`, and edited the existing configuration appropriately.


![IMG_20231018_012938.jpg](https://github.com/eupnea-linux-backup/eupnea-utils/assets/3063132/817ce812-7e24-4727-b063-48c82777501a)

